### PR TITLE
Fixing command in the README to include proper package prefix and nod…

### DIFF
--- a/javascript/01-hello-world/README.md
+++ b/javascript/01-hello-world/README.md
@@ -2,5 +2,5 @@ NodeJS Hello World
 ==================
 
 ```sh
-$ ops pkg load node_v14.2.0 -a ex.js
+$ ops pkg load eyberg/node:20.5.0 -a ex.js
 ```


### PR DESCRIPTION
…e version

The command to start the example application is missing a package prefix. I assume that a breaking change requiring package prefixes was made, but the documentation was not updated. Also, the node version in the command is older, updating it to a new one.